### PR TITLE
Fix error when replication ids include hyphens

### DIFF
--- a/src/supabase-replication.ts
+++ b/src/supabase-replication.ts
@@ -119,8 +119,15 @@ export class SupabaseReplication<RxDocType> extends RxReplicationState<
     const realtimeChanges = new Subject<
       RxReplicationPullStreamItem<RxDocType, SupabaseReplicationCheckpoint>
     >()
+    const replicationIdentifierHash = options.collection.database.hashFunction(
+      [
+        options.collection.database.name,
+        options.collection.name,
+        options.replicationIdentifier,
+      ].join("|")
+    )
     super(
-      options.replicationIdentifier,
+      replicationIdentifierHash,
       options.collection,
       options.deletedField || DEFAULT_DELETED_FIELD,
       options.pull && {


### PR DESCRIPTION
Hey, awesome project! It works great but I came across two bugs while using it so I'm putting up PRs for them. For this PR, I'm getting an error if there are hyphens in my replication identifier:
```
Error: malformatted revision: 1-rxdbreplicationmy-id
    at parseRevision (webpack-internal:///../../node_modules/rxdb/dist/es/plugins/utils/utils-revision.js:10:11)
    at createRevision (webpack-internal:///../../node_modules/rxdb/dist/es/plugins/utils/utils-revision.js:31:51)
    at getMetaWriteRow (webpack-internal:///../../node_modules/rxdb/dist/es/replication-protocol/meta-instance.js:98:80)
    at eval (webpack-internal:///../../node_modules/rxdb/dist/es/replication-protocol/upstream.js:199:97)
    at async Promise.all (index 0)
    at async eval (webpack-internal:///../../node_modules/rxdb/dist/es/replication-protocol/upstream.js:168:7)
```
Looking at the rxdb source code, it looks like we're meant to pass a hash of the id to super() rather than the id itself https://github.com/pubkey/rxdb/blob/a73c91add858097ca4138009e52531a21eb76ec8/src/plugins/replication/index.ts#L88. An example usage from the rxdb code is here which I based this PR on https://github.com/pubkey/rxdb/blob/a73c91add858097ca4138009e52531a21eb76ec8/src/plugins/replication/index.ts#LL461C13-L461C13