### PR TITLE
Fix realtime when there are multiple collections

### DIFF
--- a/src/supabase-replication.ts
+++ b/src/supabase-replication.ts
@@ -269,7 +269,7 @@ export class SupabaseReplication<RxDocType> extends RxReplicationState<
 
   private watchPostgresChanges() {
     this.realtimeChannel = this.options.supabaseClient
-      .channel("any")
+      .channel(`rxdb-supabase-${this.replicationIdentifierHash}`)
       .on("postgres_changes", { event: "*", schema: "public", table: this.table }, (payload) => {
         if (payload.eventType === "DELETE" || !payload.new) return // Should have set _deleted field already
         //console.debug('Realtime event received:', payload)


### PR DESCRIPTION
If I set up two `SupabaseReplication`, I only get realtime updates from the second one. I assume because the second one clobbers the channel used by the first one. So this makes sure we always use a unique channel name.