### PR TITLE
build: expand npm and node version requirements to allow newer versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   "types": "./build/src/supabase-replication.d.ts",
   "license": "MIT",
   "engines": {
-    "node": "^18.15.0",
-    "npm": "^9.5.0"
+    "node": ">=18.15.0",
+    "npm": ">=9.5.0"
   },
   "volta": {
     "node": "18.15.0",


### PR DESCRIPTION
I also ran into issue #20, running node v18 and npm v10 locally.

Is there a reason this project requires only node v18 and npm v9?

If not, this PR expands the engine requirements to allow newer versions as well.